### PR TITLE
Update version to 1.83.7

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/0001-remove-pinning-version.patch
+++ b/recipe/0001-remove-pinning-version.patch
@@ -1,0 +1,23 @@
+--- pyproject.toml	2026-04-29 13:37:47
++++ pyproject.toml	2026-04-29 13:36:36
+@@ -25,15 +25,15 @@
+ fastuuid = "0.14.0"
+ httpx = "0.28.1"
+ openai = "2.30.0"
+-python-dotenv = "1.0.1"
++python-dotenv = ">=1.0.1"
+ tiktoken = "0.12.0"
+-importlib-metadata = "8.5.0"
++importlib-metadata = ">=8.5.0"
+ tokenizers = "0.22.2"
+-click = "8.1.8"
++click = ">=8.1.8"
+ jinja2 = "3.1.6"
+ aiohttp = "3.13.5"
+-pydantic = "2.12.5"
+-jsonschema = "4.23.0"
++pydantic = ">=2.12.5"
++jsonschema = ">=4.23.0"
+ numpydoc = {version = "1.8.0", optional = true} # not in Docker or PyPI proxy extra
+ 
+ uvicorn = {version = "0.33.0", optional = true}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "litellm" %}
-{% set version = "1.82.4" %}
+{% set version = "1.83.7" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,9 @@ package:
 
 source:
   - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 9c52b1c0762cb0593cdc97b26a8e05004e19b03f394ccd0f42fac82eff0d4980
+    sha256: e2f2cb99df2e2b2eab63f1354faa45c88dd7c8d40c18eb648afb1b349c689633
+    patches:
+      - 0001-remove-pinning-version.patch
 
 build:
   number: 0
@@ -24,56 +26,60 @@ requirements:
     - wheel
   run:
     - python
-    - fastuuid >=0.13.0
-    - httpx >=0.23.0
-    - openai >=2.8.0
-    - python-dotenv >=0.2.0
-    - tiktoken >=0.7.0
-    - importlib-metadata >=6.8.0
-    - tokenizers
-    - click
-    - jinja2 >=3.1.2,<4.0.0
-    - aiohttp >=3.10
-    - pydantic >=2.5.0,<3.0.0
+    - fastuuid >=0.14.0
+    - httpx >=0.28.1
+    - openai >=2.30.0
+    - python-dotenv >=1.0.1
+    - tiktoken >=0.12.0
+    - importlib-metadata >=8.5.0
+    - tokenizers >=0.22.2
+    - click >=8.1.8
+    - jinja2 >=3.1.6,<4.0.0
+    - aiohttp >=3.13.5
+    - pydantic >=2.12.5,<3.0.0
     - jsonschema >=4.23.0,<5.0.0
   run_constrained:
-    - uvicorn >=0.32.1,<1.0.0
+    - uvicorn >=0.33.0,<1.0.0
     # Removed to add py314 support
     #- uvloop >=0.21.0,<0.22.0  # [not win]
     - gunicorn >=23.0.0,<24.0.0
-    - fastapi >=0.120.1,<1.0.0
-    - pyyaml >=6.0.1,<7.0.0
-    - orjson >=3.9.7,<4.0.0
-    - apscheduler >=3.10.4,<4.0.0
+    - fastapi >=0.124.4,<1.0.0
+    - pyyaml >=6.0.3,<7.0.0
+    - orjson >=3.10.15,<4.0.0
+    - apscheduler >=3.11.2,<4.0.0
     - fastapi-sso >=0.16.0,<0.17.0
     - pyjwt >=2.12.0,<3.0.0  # [py>=39]
     - python-multipart >=0.0.20
     - prisma >=0.11.0,<0.12.0
-    - azure-identity >=1.15.0,<2.0.0  # [py>=39]
-    - azure-keyvault-secrets >=4.8.0,<5.0.0
-    - azure-storage-blob >=12.25.1,<13.0.0
-    - google-cloud-kms >=2.21.3,<3.0.0
+    - azure-identity >=1.25.3,<2.0.0  # [py>=39]
+    - azure-keyvault-secrets >=4.10.0,<5.0.0
+    - azure-storage-blob >=12.28.0,<13.0.0
+    - google-cloud-kms >=2.24.2,<3.0.0
     - google-cloud-iam >=2.19.1,<3.0.0
-    - google-cloud-aiplatform >=1.38.0
-    - resend >=0.8.0
-    - pynacl >=1.5.0,<2.0.0
+    - google-cloud-aiplatform >=1.133.0
+    - resend >=2.23.0
+    - pynacl >=1.6.2,<2.0.0
     - websockets >=15.0.1,<16.0.0
-    - boto3 >=1.40.76,<2.0.0
+    - boto3 >=1.42.80,<2.0.0
     - redisvl >=0.4.1,<0.5.0  # [py>=39 or py<314]
-    - mcp >=1.25.0,<2.0.0  # [py>=310]
-    - a2a-sdk >=0.3.22,<0.4.0  # [py>=310]
-    - litellm-proxy-extras >=0.4.57,<0.5.0
+    - mcp >=1.26.0,<2.0.0  # [py>=310]
+    - a2a-sdk >=0.3.25,<0.4.0  # [py>=310]
+    - litellm-proxy-extras >=0.4.65,<0.5.0
     # Removed to add py314 support
-    #- rich >=13.7.1,<14.0.0
-    - litellm-enterprise >=0.1.33,<0.2.0
-    - diskcache >=5.6.1,<6.0.0
-    - polars >=1.31.0,<2.0.0  # [py>=310]
+    #- rich >=13.9.4,<14.0.0
+    - litellm-enterprise >=0.1.37,<0.2.0
+    - diskcache >=5.6.3,<6.0.0
+    - polars >=1.39.3,<2.0.0  # [py>=310]
     - semantic-router >=0.1.12  # [py>=39 or py<314]
-    - mlflow >3.1.4  # [py>=310]
+    - mlflow >=3.9.0  # [py>=310]
     - soundfile >=0.12.1,<1.0.0
-    - pyroscope-io >=0.8,<0.9  # [not win]
-    - grpcio >=1.62.3,!=1.68.*,!=1.69.*,!=1.70.*,!=1.71.0,!=1.71.1,!=1.72.0,!=1.72.1,!=1.73.0  # [py<314]
-    - grpcio >=1.75.0  # [py>=314]
+    - pyroscope-io >=0.8.16,<0.9  # [not win]
+    - grpcio >=1.80.0
+    - numpydoc >=1.8.0
+    - backoff >=2.2.1
+    - rq >=2.7.0
+    - PyJWT >=2.12.1 # [py>=39]
+    - cryptography >=43.0.3
 
 # Tests removed: almost all of them are skipped in the end because of dependencies we don't have like fastapi_sso and others.
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,10 +34,10 @@ requirements:
     - importlib-metadata >=8.5.0
     - tokenizers >=0.22.2
     - click >=8.1.8
-    - jinja2 >=3.1.6,<4.0.0
+    - jinja2 >=3.1.6
     - aiohttp >=3.13.5
-    - pydantic >=2.12.5,<3.0.0
-    - jsonschema >=4.23.0,<5.0.0
+    - pydantic >=2.12.5
+    - jsonschema >=4.23.0
   run_constrained:
     - uvicorn >=0.33.0,<1.0.0
     # Removed to add py314 support


### PR DESCRIPTION
litellm 1.83.7

**Destination channel:** defaults

### Links

- [PKG-14358](https://anaconda.atlassian.net/browse/PKG-14358) 
- [Upstream repository](https://github.com/BerriAI/litellm)

### Explanation of changes:
- New version number
- Update dependencies
- Remove pinning dependencies version because the exact versions don't support build with python 3.14. We have newer versions of packages with are compatible.


[PKG-14358]: https://anaconda.atlassian.net/browse/PKG-14358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ